### PR TITLE
Fix for Hex Colors

### DIFF
--- a/src/main/java/ch/njol/skript/util/Utils.java
+++ b/src/main/java/ch/njol/skript/util/Utils.java
@@ -589,7 +589,7 @@ public abstract class Utils {
 	@SuppressWarnings("null")
 	@Nullable
 	public static ChatColor parseHexColor(String hex) {
-		if (!HEX_SUPPORTED || !hex.matches("(?i)#[0-9a-z]{6}")) // Proper hex code validation
+		if (!HEX_SUPPORTED || !hex.matches("(?i)#?[0-9a-z]{6}")) // Proper hex code validation
 			return null;
 		
 		hex = hex.replace("#", "");


### PR DESCRIPTION
### Description
Last change broke hex colors, they didn't parse right when set to a variable or called from a function, etc.
Tested a little and this seems to fix it.

---
**Target Minecraft Versions:** 1.16+
**Requirements:** Skript
**Related Issues:** https://github.com/SkriptLang/Skript/issues/4527
